### PR TITLE
Update dependencies and stabilize project code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/target/
+
+.settings
+.project
+.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -7,18 +7,29 @@
     <groupId>Applitools</groupId>
     <artifactId>TestResultHandler</artifactId>
     <version>1.0-SNAPSHOT</version>
+    
+    <properties>
+    <maven.compiler.source>18</maven.compiler.source>
+    <maven.compiler.target>18</maven.compiler.target>
+    </properties>
 
     <dependencies>
 
         <dependency>
             <groupId>com.applitools</groupId>
-            <artifactId>eyes-selenium-java3</artifactId>
-            <version>RELEASE</version>
+            <artifactId>eyes-sdk-core-java3</artifactId>
+            <version>5.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20160810</version>
+            <version>20220924</version>
+        </dependency>
+        <dependency>
+            <groupId>com.applitools</groupId>
+            <artifactId>eyes-selenium-java3</artifactId>
+            <version>5.0.0</version>
+            <scope>test</scope>
         </dependency>
 
 

--- a/src/test/java/com/applitools/eyes/results/handler/example/DownloadDiffExample.java
+++ b/src/test/java/com/applitools/eyes/results/handler/example/DownloadDiffExample.java
@@ -1,3 +1,5 @@
+package com.applitools.eyes.results.handler.example;
+
 import ApplitoolsTestResultHandler.ApplitoolsTestResultsHandler;
 import ApplitoolsTestResultHandler.ResultStatus;
 import com.applitools.eyes.RectangleSize;
@@ -6,7 +8,6 @@ import com.applitools.eyes.TestResults;
 import com.applitools.eyes.selenium.Eyes;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
 
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
@@ -14,7 +15,8 @@ import java.util.List;
 
 public class DownloadDiffExample {
 
-    public static void main(String[] args) throws Exception {
+    // TODO - convert this into a JUnit test so it's clear this isn't intended to be used as a CLI command
+    public static void main(String[] foo) throws Exception {
 
         WebDriver driver = new ChromeDriver();
         Eyes eyes = new Eyes();
@@ -86,7 +88,7 @@ public class DownloadDiffExample {
             //Get the status of each step (Pass / Unresolved / New / Missing).
             ResultStatus[] results = testResultHandler.calculateStepResults();
             for (int i=0 ; i< results.length; i++){
-                System.out.println("The result of step "+(i+1)+" is "+ results[i]);
+                System.out.println("The result of step "+(i+1)+"/"+results.length + " " + names[i] + " is "+ results[i]);
             }
 
         }


### PR DESCRIPTION
Updating to the latest `eyes-selenium-java3` SDK and `org.json.json` library.

Stabilizing code and reducing the dependency profile to the minimum for the released JAR.

The ApplitoolsTestResultsHandler class itself does not actually use Selenium and the release manifest should not depend upon `eyes-selenium-java3` nor its full dependency profile.  It really only needs the `eyes-sdk-core-java3` library, so the project can depend directly that JAR, enabling any project that uses an Eyes Java SDK to incorporate the TestResultsHandler.

Reducing the `eyes-selenium-java3` dependency to test scope only and moving the example code into `src/test/java` so that it is no longer included in the released JAR.   We can later convert the example code into a JUnit test to make it clear that it should not be used as a CLI command and also potentially use it to test the implementation of this project.